### PR TITLE
feat(backend): implementacion del CRUD de contenido

### DIFF
--- a/src/main/java/com/healthybites/api/AdminCategoryController.java
+++ b/src/main/java/com/healthybites/api/AdminCategoryController.java
@@ -1,7 +1,0 @@
-package com.healthybites.api;
-
-public class AdminCategoryController {
-    void Hello() {
-        System.out.println("Hello from AdminCategoryController");
-    }
-}

--- a/src/main/java/com/healthybites/api/AdminContenidoController.java
+++ b/src/main/java/com/healthybites/api/AdminContenidoController.java
@@ -1,0 +1,58 @@
+package com.healthybites.api;
+
+import com.healthybites.model.entity.Contenido;
+import com.healthybites.service.AdminContenidoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/admin/contenido")
+public class AdminContenidoController {
+    private final AdminContenidoService adminContenidoService;
+
+    @GetMapping
+    public ResponseEntity<List<Contenido>> getAllContenido() {
+        //return ResponseEntity.ok(adminContenidoService.getAll());
+        List<Contenido> contenidos = adminContenidoService.getAll();
+        return new ResponseEntity<List<Contenido>>(contenidos, HttpStatus.OK);
+    }
+
+    @GetMapping("/page")
+    public ResponseEntity<Page<Contenido>> paginateContenidos(
+            @PageableDefault(size = 5, sort = "titulo")Pageable pageable) {
+        Page<Contenido> contenidos = adminContenidoService.paginate(pageable);
+        return new ResponseEntity<Page<Contenido>>(contenidos, HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Contenido> getContenidoById(@PathVariable("id") Integer id) {
+        Contenido contenidos = adminContenidoService.findById(id);
+        return new ResponseEntity<Contenido>(contenidos, HttpStatus.OK);
+    }
+
+    @PostMapping
+    public ResponseEntity<Contenido> createContenido(@RequestBody Contenido contenido) {
+        Contenido newContenido = adminContenidoService.create(contenido);
+        return new ResponseEntity<Contenido>(newContenido, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Contenido> updateContenido(@PathVariable("id") Integer id, @RequestBody Contenido contenido) {
+        Contenido updateContenido = adminContenidoService.update(id, contenido);
+        return new ResponseEntity<Contenido>(updateContenido, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Contenido> deleteContenido(@PathVariable("id") Integer id) {
+        adminContenidoService.delete(id);
+        return new ResponseEntity<Contenido>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/com/healthybites/model/entity/Contenido.java
+++ b/src/main/java/com/healthybites/model/entity/Contenido.java
@@ -1,5 +1,6 @@
 package com.healthybites.model.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.healthybites.model.enums.CategoriaContenido;
 import com.healthybites.model.enums.TipoContenido;
 import jakarta.persistence.*;
@@ -25,6 +26,7 @@ public class Contenido {
     @Enumerated(EnumType.STRING)
     private CategoriaContenido categoria;
 
+    @JsonIgnore
     @ManyToOne
     @JoinColumn(name = "administrador_id", referencedColumnName = "id", foreignKey = @ForeignKey(name = "FK_CONTENIDO_ADMINISTRADOR"))
     private Administrador administrador;

--- a/src/main/java/com/healthybites/repository/CategoryRepository.java
+++ b/src/main/java/com/healthybites/repository/CategoryRepository.java
@@ -1,5 +1,0 @@
-package com.healthybites.repository;
-
-public interface CategoryRepository {
-    void Hello();
-}

--- a/src/main/java/com/healthybites/repository/ContenidoRepository.java
+++ b/src/main/java/com/healthybites/repository/ContenidoRepository.java
@@ -1,0 +1,7 @@
+package com.healthybites.repository;
+
+import com.healthybites.model.entity.Contenido;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContenidoRepository extends JpaRepository<Contenido, Integer> {
+}

--- a/src/main/java/com/healthybites/service/AdminCategoryService.java
+++ b/src/main/java/com/healthybites/service/AdminCategoryService.java
@@ -1,5 +1,0 @@
-package com.healthybites.service;
-
-public interface AdminCategoryService {
-    void Hello();
-}

--- a/src/main/java/com/healthybites/service/AdminContenidoService.java
+++ b/src/main/java/com/healthybites/service/AdminContenidoService.java
@@ -1,0 +1,15 @@
+package com.healthybites.service;
+
+import com.healthybites.model.entity.Contenido;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import java.util.List;
+
+public interface AdminContenidoService {
+    List<Contenido> getAll();
+    Page<Contenido> paginate(Pageable pageable);
+    Contenido findById(Integer id);
+    Contenido create(Contenido contenido);
+    Contenido update(Integer id, Contenido updateContenido);
+    void delete(Integer id);
+}

--- a/src/main/java/com/healthybites/service/impl/AdminCategoryServiceImpl.java
+++ b/src/main/java/com/healthybites/service/impl/AdminCategoryServiceImpl.java
@@ -1,7 +1,0 @@
-package com.healthybites.service.impl;
-
-public class AdminCategoryServiceImpl {
-    public void Hello() {
-        System.out.println("Hello from AdminCategoryServiceImpl");
-    }
-}

--- a/src/main/java/com/healthybites/service/impl/AdminContenidoServiceImpl.java
+++ b/src/main/java/com/healthybites/service/impl/AdminContenidoServiceImpl.java
@@ -1,0 +1,62 @@
+package com.healthybites.service.impl;
+
+import com.healthybites.model.entity.Contenido;
+import com.healthybites.repository.ContenidoRepository;
+import com.healthybites.service.AdminContenidoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class AdminContenidoServiceImpl implements AdminContenidoService {
+
+    private final ContenidoRepository contenidoRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<Contenido> getAll() {
+        return contenidoRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Page<Contenido> paginate(Pageable pageable) {
+        return contenidoRepository.findAll(pageable);
+    }
+
+    @Transactional
+    @Override
+    public Contenido create(Contenido contenido) {
+        return contenidoRepository.save(contenido);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Contenido findById(Integer id) {
+        return contenidoRepository.findById(id).
+                orElseThrow(() -> new RuntimeException("Contenido no encontrado"));
+    }
+
+    @Transactional
+    @Override
+    public Contenido update(Integer id, Contenido updateContenido) {
+        Contenido contenidoFromDb = findById(id);
+        contenidoFromDb.setTitulo(updateContenido.getTitulo());
+        contenidoFromDb.setDescripcion(updateContenido.getDescripcion());
+        contenidoFromDb.setTipoContenido(updateContenido.getTipoContenido());
+        contenidoFromDb.setCategoria(updateContenido.getCategoria());
+        return contenidoRepository.save(contenidoFromDb);
+    }
+
+    @Transactional
+    @Override
+    public void delete(Integer id) {
+        Contenido contenido = findById(id);
+        contenidoRepository.delete(contenido);
+    }
+}


### PR DESCRIPTION
Este pull requests añade la implementacion completa de las operacioens CRUD (Crear, Leer, Actualizar, Eliminar) para la entidad `Contenido`

### Cambios realizados

- Se añadio el repositorio `ContenidoRepository` con metodos básicos de CRUD.
- Se creo el servicio `AdminContenidoService`y `AdminContenidoServiceImpl` con la lógica de negocio para gestionar contenidos.
- Se implementó el controlador `AdminContenidoController` con endpoints REST para las operaciones CRUD.
- Se realizaron las pruebas para verificar la funcionalidad del CRUD mediante Postman.